### PR TITLE
Fix resources block indentation and add nodeSelector block

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: ebpf-exporter
-version: 0.1.0
+version: 0.1.1

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -39,9 +39,13 @@ spec:
           name: kernel
         - mountPath: /lib/modules/
           name: modules
-      resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+        resources:
+          {{- toYaml .Values.resources | trim | nindent 10 }}
       dnsPolicy: ClusterFirst
+      {{- if not (empty .Values.nodeSelector) }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | trim | nindent 8 }}
+      {{- end }}
       restartPolicy: Always
       schedulerName: default-scheduler
       volumes:


### PR DESCRIPTION
The `resources` block needs to be indented two additional spaces in order to work. I also added a `trim` to the pipeline so there isn't an extra newline after it.

The `values.yaml` file has a `nodeSelector`, but it's not being used in the DaemonSet. I've added that to this PR as well.