### PR TITLE
Support supplying alternate command to container

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: ebpf-exporter
-version: 0.1.0
+version: 0.1.1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Parameter | Description | Default
 `nodeSelector` | node selector rules | `{}`
 `tolerations` | node tolerations | `[]`
 `affinity` | pod affinity rules | `{}`
+`command` | supply alternate command to container | `{}`
 
 ## Docker file
 The docker file to build images can be located at

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -24,6 +24,10 @@ spec:
     spec:
       containers:
       - name: {{ .Release.Name  }}
+        {{- if not (empty .Values.command) }}
+        command:
+          {{- toYaml .Values.command | trim | nindent 10 }}
+        {{- end }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:

--- a/values.yaml
+++ b/values.yaml
@@ -58,3 +58,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# Override the command for the container.
+command: nil


### PR DESCRIPTION
This Helm chart already supports using an image other than `vanneback/ebpf_exporter`. I don't have any issue with that container, but there are more up-to-date ones available in Dockerhub. I'd like to be able to use those images (or a custom image that I build), while still using this Helm chart.

This PR adds a `command` variable, which can be used to supply an alternate container command. This is necessary for Docker images that don't reference `--config.file=/etc/config/ebpf-config.yaml` in the same way that `ebpf_exporter_dockerfile` does.